### PR TITLE
Patch #93 and #95

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 2.8.2
++ Released: 2018-05-09
++ [[#93](https://github.com/aguywithanidea/heypublisher-submission-manager/issues/93)] : Fixed issue where it was impossible to edit an email template for a multi-word submission state.  93 was fixed without checking the edits which uses the same logic.
++ [[#95](https://github.com/aguywithanidea/heypublisher-submission-manager/issues/95)] : Fixed issue with undefined constants throwing warnings in versions of PHP > 7.0
+
 ### 2.8.1
 + Released: 2018-03-14
 + [[#92](https://github.com/aguywithanidea/heypublisher-submission-manager/issues/92)] : Fixed issue where publishers are unable to create an email template if they don't already have an email template defined.

--- a/README.md
+++ b/README.md
@@ -117,5 +117,5 @@ HeyPublisher builds tools for writers and publishers.  Find out more by visiting
 
 + WordPress minimum version: 4.0
 + WordPress version tested up to: 4.9.4
-+ Current Stable Tag: 2.8.1
++ Current Stable Tag: 2.8.2
 + License: GPLv2

--- a/heypublisher-sub-mgr.php
+++ b/heypublisher-sub-mgr.php
@@ -5,7 +5,7 @@ Plugin URI: https://www.heypublisher.com
 Description: HeyPublisher is a better way of managing unsolicited submissions directly within WordPress.
 Author: HeyPublisher
 Author URI: https://www.heypublisher.com
-Version: 2.8.1
+Version: 2.8.2
 
   Copyright 2010-2014 Loudlever, Inc. (wordpress@loudlever.com)
   Copyright 2014-2018 Richard Luck (https://github.com/aguywithanidea/)
@@ -75,6 +75,7 @@ define('HEY_DIR', dirname(plugin_basename(__FILE__)));
   2.7.0 => 71
   2.8.0 => 72
   2.8.1 => 73
+  2.8.2 => 74
 
 ---------------------------------------------------------------------------------
 */
@@ -82,10 +83,10 @@ define('HEY_DIR', dirname(plugin_basename(__FILE__)));
 // Configs specific to the plugin
 // Build Number (must be a integer)
 define('HEY_BASE_URL', get_option('siteurl').'/wp-content/plugins/'.HEY_DIR.'/');
-define("HEYPUB_PLUGIN_BUILD_DATE", "2018-03-14");
+define("HEYPUB_PLUGIN_BUILD_DATE", "2018-05-09");
 // Version Number (can be text)
-define("HEYPUB_PLUGIN_BUILD_NUMBER", "73");  // This controls whether or not we get upgrade prompt
-define("HEYPUB_PLUGIN_VERSION", "2.8.1");
+define("HEYPUB_PLUGIN_BUILD_NUMBER", "74");  // This controls whether or not we get upgrade prompt
+define("HEYPUB_PLUGIN_VERSION", "2.8.2");
 
 # Base domain
 $domain = 'https://www.heypublisher.com';
@@ -405,8 +406,8 @@ function heypub_uninit() {
   $install = $hp_xml->install;
   if ($install != FALSE && isset($install['user_oid']) ) {
     // disable the publisher in the db
-    $opts[accepting_subs] = false;
-    $opts[genres_list] = false;
+    $opts['accepting_subs'] = false;
+    $opts['genres_list'] = false;
     $opts['guide'] = get_permalink($opts['sub_guide_id']);
     $hp_xml->update_publisher($opts,true);
   }

--- a/include/HeyPublisherXML/HeyPublisherXML.class.php
+++ b/include/HeyPublisherXML/HeyPublisherXML.class.php
@@ -56,8 +56,8 @@ class HeyPublisherXML {
   }
 
   public function get_category_mapping() {
-    if ($this->config[categories]) {
-      return $this->config[categories];
+    if ($this->config['categories']) {
+      return $this->config['categories'];
     }
     else {
       return array();
@@ -65,7 +65,7 @@ class HeyPublisherXML {
   }
 
   public function set_category_mapping($map) {
-    $this->config[categories] = $map;
+    $this->config['categories'] = $map;
     return;
   }
 
@@ -87,12 +87,12 @@ class HeyPublisherXML {
   }
 
   public function set_install_option($key,$val){
-    $this->install[$key] = $val;
+    $this->install["$key"] = $val;
   }
 
   public function get_install_option($key){
-    if ($this->install[$key]) {
-      return $this->install[$key];
+    if ($this->install["$key"]) {
+      return $this->install["$key"];
     }
     return false;
   }
@@ -152,21 +152,21 @@ class HeyPublisherXML {
   }
 
   public function set_config_option($key,$val){
-    $this->config[$key] = $val;
+    $this->config["$key"] = $val;
   }
 
   public function set_config_option_bulk($hash){
     $allowed = array_keys($this->config_options_definition());
     foreach ($hash as $key=>$val) {
       if (in_array($key,$allowed)) {
-        $this->config[$key] = $val;
+        $this->config["$key"] = $val;
       }
     }
   }
 
   public function get_config_option($key){
-    if ($this->config[$key]) {
-      return $this->config[$key];
+    if ($this->config["$key"]) {
+      return $this->config["$key"];
     }
     return false;
   }
@@ -269,9 +269,9 @@ class HeyPublisherXML {
 
   function update_publisher_mailchimp($post) {
     $xml = null;
-    $active =   htmlentities(stripslashes($post[mailchimp_active]));
-    $api_key =  htmlentities(stripslashes($post[mailchimp_api_key]));
-    $list_id =  htmlentities(stripslashes($post[mailchimp_list_id]));
+    $active =   htmlentities(stripslashes($post['mailchimp_active']));
+    $api_key =  htmlentities(stripslashes($post['mailchimp_api_key']));
+    $list_id =  htmlentities(stripslashes($post['mailchimp_list_id']));
     // if ($post[mailchimp_active]) {
     $xml =<<< EOF
     <mailchimp>
@@ -286,9 +286,9 @@ EOF;
 
   function update_publisher_categories($post) {
     $ret = null;
-    if ($post[accepting_subs] && $post[genres_list]) {
+    if ($post['accepting_subs'] && $post['genres_list']) {
       $cat_array = array();
-      foreach ($post[genres_list] as $name => $id) {
+      foreach ($post['genres_list'] as $name => $id) {
         $cat_array[] = sprintf('<category>%s</category>', $id);
       }
       if (FALSE != $cat_array) {
@@ -299,8 +299,8 @@ EOF;
   }
 
   function update_publisher_reading_period($post) {
-    $bool = $this->boolean($post[reading_period]);
-    if ($post[reading_period]) {
+    $bool = $this->boolean($post['reading_period']);
+    if ($post['reading_period']) {
       $start = $post['start_date'];
       $end = $post['end_date'];
       $ret = "<reading_period><reading_start_date>$start</reading_start_date><reading_end_date>$end</reading_end_date></reading_period>";
@@ -320,9 +320,9 @@ EOF;
     }
   }
   function update_publisher_paying_market($post) {
-    $bool = $this->boolean($post[paying_market]);
-    if ($post[paying_market]) {
-      $val = htmlentities(stripslashes($post[paying_market_range]));
+    $bool = $this->boolean($post['paying_market']);
+    if ($post['paying_market']) {
+      $val = htmlentities(stripslashes($post['paying_market_range']));
       $ret = "<paying_market><paying_market_amount>$val</paying_market_amount></paying_market>";
     } else {
       $ret = "<paying_market>$bool</paying_market>";
@@ -364,25 +364,25 @@ EOF;
     $categories = $this->update_publisher_categories($post);
     $mailchimp = $this->update_publisher_mailchimp($post);
     $reading = $this->update_publisher_reading_period($post);
-    $simulsubs = $this->boolean($post[simu_subs]);
-    $multisubs = $this->boolean($post[multi_subs]);
-    $reprints = $this->boolean($post[reprint_subs]);
-    $accepting_subs  = $this->boolean($post[accepting_subs]);
+    $simulsubs = $this->boolean($post['simu_subs']);
+    $multisubs = $this->boolean($post['multi_subs']);
+    $reprints = $this->boolean($post['reprint_subs']);
+    $accepting_subs  = $this->boolean($post['accepting_subs']);
     $paying = $this->update_publisher_paying_market($post);
     # no htmlentities here, otherwise " becomes %quote; and cronks the seo name
-    $name = stripslashes($post[name]);
-    $issn = htmlentities(stripslashes($post[issn]));
-    $established = htmlentities(stripslashes($post[established]));
-    $editor = htmlentities(stripslashes($post[editor_name]));
-    $editor_email = htmlentities(stripslashes($post[editor_email]));
-    $address = htmlentities(stripslashes($post[address]));
-    $city = htmlentities(stripslashes($post[city]));
-    $state = htmlentities(stripslashes($post[state]));
-    $zipcode = htmlentities(stripslashes($post[zipcode]));
-    $country = htmlentities(stripslashes($post[country]));
-    $twitter = htmlentities(stripslashes($post[twitter]));
-    $facebook = htmlentities(stripslashes($post[facebook]));
-    $url = htmlentities(stripslashes($post[url]));
+    $name = stripslashes($post['name']);
+    $issn = htmlentities(stripslashes($post['issn']));
+    $established = htmlentities(stripslashes($post['established']));
+    $editor = htmlentities(stripslashes($post['editor_name']));
+    $editor_email = htmlentities(stripslashes($post['editor_email']));
+    $address = htmlentities(stripslashes($post['address']));
+    $city = htmlentities(stripslashes($post['city']));
+    $state = htmlentities(stripslashes($post['state']));
+    $zipcode = htmlentities(stripslashes($post['zipcode']));
+    $country = htmlentities(stripslashes($post['country']));
+    $twitter = htmlentities(stripslashes($post['twitter']));
+    $facebook = htmlentities(stripslashes($post['facebook']));
+    $url = htmlentities(stripslashes($post['url']));
 
     $uninstall = '';
     if ($uninstall_plugin) {
@@ -391,38 +391,38 @@ EOF;
 
     $post = <<<EOF
 <publisher>
-    <oid>$this->pub_oid</oid>
-    <publishertype_id>$post[pub_type]</publishertype_id>
-    <name>$name</name>
-    <url>$url</url>
-    <issn>$issn</issn>
-    <established>$established</established>
-    <circulation>$post[circulation]</circulation>
-    <sub_guideline>$post[guide]</sub_guideline>
-    <editor>$editor</editor>
-    <editor_email>$editor_email</editor_email>
-    <accepts_simultaneous_submissions>$simulsubs</accepts_simultaneous_submissions>
-    <accepts_multiple_submissions>$multisubs</accepts_multiple_submissions>
-    <accepts_reprints>$reprints</accepts_reprints>
-    <now_accepting_submissions>$accepting_subs</now_accepting_submissions>
-    <address>$address</address>
-    <city>$city</city>
-    <state>$state</state>
-    <zipcode>$zipcode</zipcode>
-    <country>$country</country>
-    <twitter>$twitter</twitter>
-    <facebook>$facebook</facebook>
-    <submission_url>$post[submission_url]</submission_url>
+    <oid>{$this->pub_oid}</oid>
+    <publishertype_id>{$post['pub_type']}</publishertype_id>
+    <name>{$name}</name>
+    <url>{$url}</url>
+    <issn>{$issn}</issn>
+    <established>{$established}</established>
+    <circulation>{$post['circulation']}</circulation>
+    <sub_guideline>{$post['guide']}</sub_guideline>
+    <editor>{$editor}</editor>
+    <editor_email>{$editor_email}</editor_email>
+    <accepts_simultaneous_submissions>{$simulsubs}</accepts_simultaneous_submissions>
+    <accepts_multiple_submissions>{$multisubs}</accepts_multiple_submissions>
+    <accepts_reprints>{$reprints}</accepts_reprints>
+    <now_accepting_submissions>{$accepting_subs}</now_accepting_submissions>
+    <address>{$address}</address>
+    <city>{$city}</city>
+    <state>{$state}</state>
+    <zipcode>{$zipcode}</zipcode>
+    <country>{$country}</country>
+    <twitter>{$twitter}</twitter>
+    <facebook>{$facebook}</facebook>
+    <submission_url>{$post['submission_url']}</submission_url>
     <submission_product>HeyPublisher</submission_product>
     <platform>wordpress</platform>
-    <turn_off_tidy>$post[turn_off_tidy]</turn_off_tidy>
+    <turn_off_tidy>{$post['turn_off_tidy']}</turn_off_tidy>
     <notify_submitted>1</notify_submitted>
-    <notify_read>$post[notify_read]</notify_read>
-    <notify_rejected>$post[notify_rejected]</notify_rejected>
-    <notify_published>$post[notify_published]</notify_published>
-    <notify_accepted>$post[notify_accepted]</notify_accepted>
-    <notify_under_consideration>$post[notify_under_consideration]</notify_under_consideration>
-    <notify_withdrawn>$post[notify_withdrawn]</notify_withdrawn>
+    <notify_read>{$post['notify_read']}</notify_read>
+    <notify_rejected>{$post['notify_rejected']}</notify_rejected>
+    <notify_published>{$post['notify_published']}</notify_published>
+    <notify_accepted>{$post['notify_accepted']}</notify_accepted>
+    <notify_under_consideration>{$post['notify_under_consideration']}</notify_under_consideration>
+    <notify_withdrawn>{$post['notify_withdrawn']}</notify_withdrawn>
     {$categories}
     {$reading}
     {$paying}
@@ -734,7 +734,7 @@ EOF;
   // Process the submission action with an optional message
   function submission_action($id,$action,$message=false) {
       $return = false;
-      if (!$this->submission_status[$action]) {
+      if (!$this->submission_status["$action"]) {
         $this->error = sprintf('%s is an invalid action',$action);
         // $this->print_webservice_errors();
         return $return;
@@ -799,11 +799,11 @@ EOF;
   public function sync_publisher_info() {
     $p = $this->get_publisher_info();
     if ($p) {
-      $this->set_config_option('seo_url',$p[seo_url]);
-      $this->set_config_option('homepage_first_validated_at',$p[homepage_first_validated_at]);
-      $this->set_config_option('homepage_last_validated_at',$p[homepage_last_validated_at]);
-      $this->set_config_option('guide_first_validated_at',$p[guide_first_validated_at]);
-      $this->set_config_option('guide_last_validated_at',$p[guide_last_validated_at]);
+      $this->set_config_option('seo_url',$p['seo_url']);
+      $this->set_config_option('homepage_first_validated_at',$p['homepage_first_validated_at']);
+      $this->set_config_option('homepage_last_validated_at',$p['homepage_last_validated_at']);
+      $this->set_config_option('guide_first_validated_at',$p['guide_first_validated_at']);
+      $this->set_config_option('guide_last_validated_at',$p['guide_last_validated_at']);
       // we won't store total subs and open subs
       // xml.avg_response_days(-1)   # we'll calculate this later
       // xml.avg_acceptance_rate(-1) # we'll calculate this later

--- a/include/classes/HeyPublisher/Page/Email.class.php
+++ b/include/classes/HeyPublisher/Page/Email.class.php
@@ -26,18 +26,18 @@ class Email extends \HeyPublisher\Page {
   }
 
   public function action_handler() {
-    if (isset($_REQUEST[action])) {
-      if ($_REQUEST[action] == 'create' || $_REQUEST[action] == 'update' ) {
+    if (isset($_REQUEST['action'])) {
+      if ($_REQUEST['action'] == 'create' || $_REQUEST['action'] == 'update' ) {
         $this->validate_nonced_field();
         $this->message = $this->api->update_template($_POST);
       }
-      elseif ($_REQUEST[action] == 'delete') {
+      elseif ($_REQUEST['action'] == 'delete') {
         $this->validate_nonced_field();
-        $this->message = $this->api->delete_template($_REQUEST[delete]);
+        $this->message = $this->api->delete_template($_REQUEST['delete']);
       }
       else {
         // Display the create / edit form
-        parent::page('Email Template', '', array($this,'edit_email_form'),$_REQUEST[action]);
+        parent::page('Email Template', '', array($this,'edit_email_form'),$_REQUEST['action']);
         return;
         // early exit for good behavior
       }
@@ -339,7 +339,7 @@ EOF;
       foreach($emails as $x => $hash) {
         $s = implode(' ',explode('_',$hash['submission_state']));
         $state = ucwords($s);
-        $edit = $this->get_form_url_for_page($s);
+        $edit = $this->get_form_url_for_page($hash['submission_state']);
         $delete = $this->get_form_url_for_page('delete',$hash['submission_state']);
         $html .= <<<EOF
           <tr>

--- a/include/classes/HeyPublisher/Page/Options.class.php
+++ b/include/classes/HeyPublisher/Page/Options.class.php
@@ -238,7 +238,7 @@ EOF;
     $pages = get_pages();
     $select = '';
     foreach ($pages as $p) {
-      $select .= sprintf('<option value="%s" %s>%s</option>', $p->ID, ($p->ID == $opts[sub_guide_id]) ? 'selected=selected' : null, $p->post_title);
+      $select .= sprintf('<option value="%s" %s>%s</option>', $p->ID, ($p->ID == $opts['sub_guide_id']) ? 'selected=selected' : null, $p->post_title);
     }
     $html = <<<EOF
     <h3>Submission Guidelines</h3>
@@ -266,7 +266,7 @@ EOF;
     $html = "<h3>Submission Form</h3>";
     $nopage = 'style="display:none;"';
     $yespage = '';
-    if (!$opts[sub_page_id]) {
+    if (!$opts['sub_page_id']) {
       $yespage = 'style="display:none;"';
       $nopage = '';
     }
@@ -283,7 +283,7 @@ EOF;
     $select = '';
     $pages = get_pages();
     foreach ($pages as $p) {
-      $select .= sprintf('<option value="%s" %s>%s</option>', $p->ID, ($p->ID == $opts[sub_page_id]) ? 'selected=selected' : null, $p->post_title);
+      $select .= sprintf('<option value="%s" %s>%s</option>', $p->ID, ($p->ID == $opts['sub_page_id']) ? 'selected=selected' : null, $p->post_title);
     }
     $html .= <<<EOF
       <ul>
@@ -368,7 +368,7 @@ EOF;
       $mapping .= sprintf('
         <td>%s &nbsp; <input id="cat_%s"type="checkbox" name="heypub_opt[genres_list][]" value="%s" %s onclick="HeyPublisher.clickCheck(this,\'chk_%s\');"/></td>
         <td>%s</td>',
-          $hash[name],$hash[id],$hash[id],($hash[has]) ? "checked=checked" : null,$hash[id],$this->heypub_get_category_mapping($hash[id],$hash[has])
+          $hash['name'],$hash['id'],$hash['id'],($hash['has']) ? "checked=checked" : null,$hash['id'],$this->heypub_get_category_mapping($hash['id'],$hash['has'])
       );
       $cnt ++;
     }
@@ -550,7 +550,7 @@ EOF;
         $cats = $this->xml->get_my_categories_as_hash();
         $has_genres = '0';
         foreach ($cats as $id=>$hash) {
-          if ($hash[has]) { $has_genres = '1'; }
+          if ($hash['has']) { $has_genres = '1'; }
         }
 
         $message .= "<br/><br/>To help you get started we've pre-populated the form with information we already have.";
@@ -606,12 +606,12 @@ EOF;
   // map the internal categories to HeyPub categories
   private function set_category_mapping($post) {
     $result = array();
-    if ($post[accepting_subs] && $post[genres_list]) {
-      $map = $post[category_map];
-      $genres = $post[genres_list];
+    if ($post['accepting_subs'] && $post['genres_list']) {
+      $map = $post['category_map'];
+      $genres = $post['genres_list'];
       foreach ($genres as $x) {
-        if ($map[$x]) {
-          $result[$x] = $map[$x];
+        if ($map["$x"]) {
+          $result["$x"] = $map["$x"];
         }
       }
     }
@@ -622,7 +622,7 @@ EOF;
     $html = '';
     if (empty($pub_types)) { return $html; }
     foreach ($pub_types as $id=>$hash){
-      $html .= sprintf('<option value="%s" %s>%s</option>',$hash[id],($hash[has]) ? "selected=selected" : null, $hash[name]);
+      $html .= sprintf('<option value="%s" %s>%s</option>',$hash['id'],($hash['has']) ? "selected=selected" : null, $hash['name']);
     }
     return $html;
   }
@@ -634,7 +634,7 @@ EOF;
     $map = $this->xml->get_category_mapping();
     $list = wp_dropdown_categories(
       array(
-        'selected' => ($map[$id]) ? $map[$id] : 0,
+        'selected' => ($map["$id"]) ? $map["$id"] : 0,
         'id' => "chk_$id",
         'hide_empty' => 0,
         'name' => "heypub_opt[category_map][$id]",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_i
 Tags: accept submissions, anonymous, contributor, custom post interface, guest blog posts, online applications, slushpile, submission form, submission manager, submission, unregistered user, heypublisher
 Requires at least: 4.0
 Tested up to: 4.9.4
-Stable Tag: 2.8.1
+Stable Tag: 2.8.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -110,6 +110,11 @@ Yes - you can define custom response templates that contain whatever message you
 11. Reimport.  If a writer modifies a submission you have already 'Accepted' - you can re-import the submission into WordPress by selecting the "Reimport Into WordPress" value from the drop-down and clicking the "Update Submission" button.
 
 == Changelog ==
+
+= 2.8.2 =
+* Released: 2018-05-09
+* Fixed issue where it was impossible to edit an email template for a multi-word submission state.  2.8.1 fixed issue for deletes but not edits, which uses the same logic.
+* Fixed issue with undefined constants throwing warnings in versions of PHP > 7.0
 
 = 2.8.1 =
 * Released: 2018-03-14


### PR DESCRIPTION
PHP 7.1+ throws warnings when hash keys are unquoted.  Fixed all occurrences that I could find.