### PR TITLE
fixing styling issue and validating against 5.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ difflist
 
 # ignore the svn control files
 .svn
-
+*heypublisher.css.map
+error.log
+.sass-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### 2.8.3
++ Released: 2019-12-06
++ [[#98](https://github.com/aguywithanidea/heypublisher-submission-manager/issues/98)] : Added link to the Statuscake status page, in cases where errors are thrown.
++ Additionally ....
+  + Validated functionality through [WordPress Version 5.3](https://wordpress.org/support/wordpress-version/version-5-3/).
+
 ### 2.8.2
 + Released: 2018-05-09
 + [[#93](https://github.com/aguywithanidea/heypublisher-submission-manager/issues/93)] : Fixed issue where it was impossible to edit an email template for a multi-word submission state.  93 was fixed without checking the edits which uses the same logic.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,6 @@ HeyPublisher builds tools for writers and publishers.  Find out more by visiting
 ## About This Plugin
 
 + WordPress minimum version: 4.0
-+ WordPress version tested up to: 4.9.4
-+ Current Stable Tag: 2.8.2
++ WordPress version tested up to: 5.3
++ Current Stable Tag: 2.8.3
 + License: GPLv2

--- a/heypublisher-sub-mgr.php
+++ b/heypublisher-sub-mgr.php
@@ -5,10 +5,11 @@ Plugin URI: https://www.heypublisher.com
 Description: HeyPublisher is a better way of managing unsolicited submissions directly within WordPress.
 Author: HeyPublisher
 Author URI: https://www.heypublisher.com
-Version: 2.8.2
+Version: 2.8.3
 
   Copyright 2010-2014 Loudlever, Inc. (wordpress@loudlever.com)
   Copyright 2014-2018 Richard Luck (https://github.com/aguywithanidea/)
+  Copyright 2019-2020 HeyPublisher, LLC (https://www.heypublisher.com/)
 
   Permission is hereby granted, free of charge, to any person
   obtaining a copy of this software and associated documentation
@@ -76,6 +77,7 @@ define('HEY_DIR', dirname(plugin_basename(__FILE__)));
   2.8.0 => 72
   2.8.1 => 73
   2.8.2 => 74
+  2.8.3 => 75
 
 ---------------------------------------------------------------------------------
 */
@@ -83,10 +85,10 @@ define('HEY_DIR', dirname(plugin_basename(__FILE__)));
 // Configs specific to the plugin
 // Build Number (must be a integer)
 define('HEY_BASE_URL', get_option('siteurl').'/wp-content/plugins/'.HEY_DIR.'/');
-define("HEYPUB_PLUGIN_BUILD_DATE", "2018-05-09");
+define("HEYPUB_PLUGIN_BUILD_DATE", "2019-12-06");
 // Version Number (can be text)
-define("HEYPUB_PLUGIN_BUILD_NUMBER", "74");  // This controls whether or not we get upgrade prompt
-define("HEYPUB_PLUGIN_VERSION", "2.8.2");
+define("HEYPUB_PLUGIN_BUILD_NUMBER", "75");  // This controls whether or not we get upgrade prompt
+define("HEYPUB_PLUGIN_VERSION", "2.8.3");
 
 # Base domain
 $domain = 'https://www.heypublisher.com';
@@ -96,6 +98,7 @@ if ($debug) {
 }
 define('HEYPUB_PLUGIN_ERROR_CONTACT','support@heypublisher.com');
 
+// TODO: This has been deprecated - but needs to be traced through code to remove references
 define('HEYPUB_DONATE_URL','https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=6XSRBYF4B3RH6');
 
 define('HEYPUB_PLUGIN_FULLPATH', dirname(__FILE__));

--- a/include/HeyPublisherXML/HeyPublisherXML.class.php
+++ b/include/HeyPublisherXML/HeyPublisherXML.class.php
@@ -587,7 +587,7 @@ EOF;
       $email = HEYPUB_PLUGIN_ERROR_CONTACT;
       $contact = <<<EOF
         <p>
-          You can check <a href='http://stats.pingdom.com/a2g0m0m0itgd' target='_blank'>our status page</a>
+          You can check <a href='https://uptime.statuscake.com/?TestID=oQBfCXVK2A' target='_blank'>our status page</a>
           for more information.  Or contact
           <a href="mailto:{$email}?subject=plugin%20error%20{$id}">
             support@heypublisher.com

--- a/include/classes/HeyPublisher/Page/Submissions.class.php
+++ b/include/classes/HeyPublisher/Page/Submissions.class.php
@@ -466,8 +466,13 @@ EOF;
   // Get the sum total of votes in a display format
   // @since  2.7.0
   private function get_vote_summary_block($votes) {
-    $up = ngettext('vote','votes',$votes['meta']['up']);
-    $down = ngettext('vote','votes',$votes['meta']['down']);
+    if (function_exists('ngettext')) {
+      $up = ngettext('vote','votes',$votes['meta']['up']);
+      $down = ngettext('vote','votes',$votes['meta']['down']);
+    } else {
+        $up = '';
+        $down = '';
+    }
     $display_votes = 'display:none;';
     if ($this->has_voted) { $display_votes = ''; }
     $html .= <<<EOF

--- a/include/css/heypublisher.css
+++ b/include/css/heypublisher.css
@@ -1,5 +1,5 @@
 /*
-  HeyPublisher Style Sheet v1.1
+  HeyPublisher Style Sheet v2.8.3
 
 */
 /*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
@@ -661,7 +661,9 @@ blockquote.heypub_summary {
     border-radius: 50%;
     border: 1px solid #CCCCCC;
     display: inline-block;
-    color: #CCCCCC; }
+    color: #CCCCCC;
+    width: 20px;
+    height: 20px; }
     .heypub-voting a:hover {
       border-color: #ffa500; }
     .heypub-voting a.vote-no.always-on, .heypub-voting a.vote-no.on {

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: heypublisher, aguywithanidea, loudlever
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=6XSRBYF4B3RH6
 Tags: accept submissions, anonymous, contributor, custom post interface, guest blog posts, online applications, slushpile, submission form, submission manager, submission, unregistered user, heypublisher
 Requires at least: 4.0
-Tested up to: 4.9.4
-Stable Tag: 2.8.2
+Tested up to: 5.3
+Stable Tag: 2.8.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -110,6 +110,11 @@ Yes - you can define custom response templates that contain whatever message you
 11. Reimport.  If a writer modifies a submission you have already 'Accepted' - you can re-import the submission into WordPress by selecting the "Reimport Into WordPress" value from the drop-down and clicking the "Update Submission" button.
 
 == Changelog ==
+
+= 2.8.3 =
+* Released: 2019-12-06
+* Added link to the Statuscake status page, in cases where errors are thrown.
+* Verified WordPress through 5.3
 
 = 2.8.2 =
 * Released: 2018-05-09

--- a/sass/heypublisher.scss
+++ b/sass/heypublisher.scss
@@ -1,5 +1,5 @@
 /*
-  HeyPublisher Style Sheet v1.1
+  HeyPublisher Style Sheet v2.8.3
 
 */
 

--- a/sass/pages/_submissions.scss
+++ b/sass/pages/_submissions.scss
@@ -150,6 +150,8 @@ float: right;
     border: $vote-button;
     display: inline-block;
     color: $vote-button-color;
+    width: 20px;
+    height: 20px;
     &:hover {
       border-color: $highlight;
     }


### PR DESCRIPTION
+ Updated error message to include link to StatusCake public page, as we've deprecated use of Pingdom
+ Fixed styling issue with vote buttons that was introduced by base WordPress 5.x style.
+ Validated everything works hunky-dory though v 5.3