### PR TITLE
GitHub based updater

### DIFF
--- a/heypublisher-sub-mgr.php
+++ b/heypublisher-sub-mgr.php
@@ -5,7 +5,7 @@ Plugin URI: https://github.com/HeyPublisher/heypublisher-submission-manager
 Description: HeyPublisher is a better way of managing unsolicited submissions directly within WordPress.
 Author: HeyPublisher
 Author URI: https://www.heypublisher.com
-Version: 2.9.1
+Version: 3.0.1
 Requires at least: 4.0
 
 
@@ -82,6 +82,7 @@ define('HEY_DIR', dirname(plugin_basename(__FILE__)));
   2.8.3 => 75
   2.9.0 => 76
   3.0.0 => 80
+  3.0.1 => 81
 
 ---------------------------------------------------------------------------------
 */
@@ -91,7 +92,7 @@ define('HEY_DIR', dirname(plugin_basename(__FILE__)));
 define('HEY_BASE_URL', get_option('siteurl').'/wp-content/plugins/'.HEY_DIR.'/');
 define("HEYPUB_PLUGIN_BUILD_DATE", "2020-06-27");
 // Version Number (can be text)
-define("HEYPUB_PLUGIN_BUILD_NUMBER", "80");  // This controls whether or not we get upgrade prompt
+define("HEYPUB_PLUGIN_BUILD_NUMBER", "81");  // This controls whether or not we get upgrade prompt
 define("HEYPUB_PLUGIN_VERSION", "3.0.1");
 define("HEYPUB_PLUGIN_TESTED", "5.3.0");
 

--- a/heypublisher-sub-mgr.php
+++ b/heypublisher-sub-mgr.php
@@ -5,7 +5,9 @@ Plugin URI: https://github.com/HeyPublisher/heypublisher-submission-manager
 Description: HeyPublisher is a better way of managing unsolicited submissions directly within WordPress.
 Author: HeyPublisher
 Author URI: https://www.heypublisher.com
-Version: 3.0.0
+Version: 2.9.1
+Requires at least: 4.0
+
 
   Copyright 2010-2014 Loudlever, Inc. (wordpress@loudlever.com)
   Copyright 2014-2018 Richard Luck (https://github.com/aguywithanidea/)
@@ -87,10 +89,11 @@ define('HEY_DIR', dirname(plugin_basename(__FILE__)));
 // Configs specific to the plugin
 // Build Number (must be a integer)
 define('HEY_BASE_URL', get_option('siteurl').'/wp-content/plugins/'.HEY_DIR.'/');
-define("HEYPUB_PLUGIN_BUILD_DATE", "2020-06-20");
+define("HEYPUB_PLUGIN_BUILD_DATE", "2020-06-27");
 // Version Number (can be text)
 define("HEYPUB_PLUGIN_BUILD_NUMBER", "80");  // This controls whether or not we get upgrade prompt
-define("HEYPUB_PLUGIN_VERSION", "3.0.0");
+define("HEYPUB_PLUGIN_VERSION", "3.0.1");
+define("HEYPUB_PLUGIN_TESTED", "5.3.0");
 
 # Base domain
 $domain = 'https://www.heypublisher.com';
@@ -126,6 +129,7 @@ define('HEYPUB_SVC_URL_RESPOND_TO_SUBMISSION','submissions/submission_action'); 
 define('HEYPUB_SVC_READ_SUBMISSION','submissions/show');                      # fetch a single submission for reading.  also sets the 'read' status
 
 # if this changes, plugin will not work.  You have been warned
+// TODO: tie token value to version / host
 define('HEYPUB_SVC_TOKEN_VALUE','534ba1c699ca9310d7acf4832e12bed87c4d5917c5063c58382e9766bca11800');
 
 // Locally stored in database
@@ -153,6 +157,14 @@ define('HEYPUB_POST_META_KEY_SUB_ID','_heypub_post_meta_key_sub_id');
 * Load all of the plugin files
 */
 global $hp_xml, $hp_base, $hp_config;
+global $hp_updater;
+
+include_once(HEYPUB_PLUGIN_FULLPATH . '/updater.php');
+$hp_updater = new HeyPublisherUpdater( __FILE__ ); // instantiate our class
+$hp_updater->set_username( 'HeyPublisher' ); // set username
+$hp_updater->set_repository( 'heypublisher-submission-manager' ); // set repo
+$hp_updater->initialize(HEYPUB_PLUGIN_TESTED); // initialize the updater
+
 // This class fetches data from and stores data in WP db
 load_template(HEYPUB_PLUGIN_FULLPATH . '/include/classes/HeyPublisher/Config.class.php');
 // XML api v1
@@ -164,7 +176,7 @@ $hp_xml = new HeyPublisherXML;
 $hp_base = new HeyPublisher;
 $hp_xml->debug = $debug;
 $hp_xml->log("Loading plugin::");
-
+$hp_xml->log(sprintf("\n HEYPUB_PLUGIN_FULLPATH = %s",HEYPUB_PLUGIN_FULLPATH));
 // These files are required for basic functions
 require_once(HEYPUB_PLUGIN_FULLPATH.'/include/heypub-template-functions.php');
 

--- a/updater.php
+++ b/updater.php
@@ -1,0 +1,167 @@
+<?php
+
+// courtesy of : https://www.smashingmagazine.com/2015/08/deploy-wordpress-plugins-with-github-using-transients/
+//
+// TODO: better organize this code
+class HeyPublisherUpdater {
+
+  private $file;
+	private $plugin;
+	private $basename;
+	private $active;
+	private $username;
+	private $repository;
+	private $authorize_token;
+	private $github_response;
+  private $tested_to = 1.0;
+
+	public function __construct( $file ) {
+
+		$this->file = $file;
+
+		add_action( 'admin_init', array( $this, 'set_plugin_properties' ) );
+
+		return $this;
+	}
+
+	public function set_plugin_properties() {
+		$this->plugin	= get_plugin_data( $this->file );
+		$this->basename = plugin_basename( $this->file );
+		$this->active	= is_plugin_active( $this->basename );
+	}
+
+	public function set_username( $username ) {
+		$this->username = $username;
+	}
+
+	public function set_repository( $repository ) {
+		$this->repository = $repository;
+	}
+
+	public function authorize( $token ) {
+		$this->authorize_token = $token;
+	}
+
+  // Get the info about version from the repository
+	private function get_repository_info() {
+	    if ( is_null( $this->github_response ) ) { // Do we have a response?
+	        $request_uri = sprintf( 'https://api.github.com/repos/%s/%s/releases', $this->username, $this->repository ); // Build URI
+
+	        if( $this->authorize_token ) { // Is there an access token?
+	            $request_uri = add_query_arg( 'access_token', $this->authorize_token, $request_uri ); // Append it
+	        }
+
+	        $response = json_decode( wp_remote_retrieve_body( wp_remote_get( $request_uri ) ), true ); // Get JSON and parse it
+
+	        if( is_array( $response ) ) { // If it is an array
+	            $response = current( $response ); // Get the first item
+	        }
+
+	        if( $this->authorize_token ) { // Is there an access token?
+	            $response['zipball_url'] = add_query_arg( 'access_token', $this->authorize_token, $response['zipball_url'] ); // Update our zip url with token
+	        }
+
+	        $this->github_response = $response; // Set it to our property
+	    }
+	}
+
+  // Ties into the WP transients
+  // This is where we put conditions for paid versions of plugin
+	public function initialize($tested=null) {
+		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'modify_transient' ), 10, 1 );
+		add_filter( 'plugins_api', array( $this, 'plugin_popup' ), 10, 3);
+		add_filter( 'upgrader_post_install', array( $this, 'after_install' ), 10, 3 );
+    if (!is_null($tested)) {
+      $this->tested_to = $tested;
+    }
+	}
+
+  // This tests to see if there is a later version on GitHub
+  // If the release on GitHub is greater, we get the upgrade prompt
+	public function modify_transient( $transient ) {
+
+		if( property_exists( $transient, 'checked') ) { // Check if transient has a checked property
+
+			if( $checked = $transient->checked ) { // Did Wordpress check for updates?
+
+				$this->get_repository_info(); // Get the repo info
+
+				$out_of_date = version_compare( $this->github_response['tag_name'], $checked[ $this->basename ], 'gt' ); // Check if we're out of date
+
+				if( $out_of_date ) {
+
+					$new_files = $this->github_response['zipball_url']; // Get the ZIP
+
+					$slug = current( explode('/', $this->basename ) ); // Create valid slug
+
+					$plugin = array( // setup our plugin info
+						'url' => $this->plugin["PluginURI"],
+						'slug' => $slug,
+						'package' => $new_files,
+						'new_version' => $this->github_response['tag_name']
+					);
+
+					$transient->response[$this->basename] = (object) $plugin; // Return it in response
+				}
+			}
+		}
+
+		return $transient; // Return filtered transient
+	}
+
+  // This displays the popup prompt and shows info about the plugin hosted on GitHub.
+  //
+	public function plugin_popup( $result, $action, $args ) {
+
+		if( ! empty( $args->slug ) ) { // If there is a slug
+
+			if( $args->slug == current( explode( '/' , $this->basename ) ) ) { // And it's our slug
+
+				$this->get_repository_info(); // Get our repo info
+
+				// Set it to an array
+				$plugin = array(
+					'name'				=> $this->plugin["Name"],
+					'slug'				=> $this->basename,
+					'requires'		=> $this->plugin["RequiresWP"],
+					'tested'			=> $this->tested_to,
+					'rating'			=> '90.0',
+					'num_ratings'	=> '23',
+					'downloaded'	=> '8669',
+					'added'				=> '2016-01-05',
+					'version'			=> $this->github_response['tag_name'],
+					'author'			=> $this->plugin["AuthorName"],
+					'author_profile'	=> $this->plugin["AuthorURI"],
+					'last_updated'		=> $this->github_response['published_at'],
+					'homepage'		=> $this->plugin["PluginURI"],
+					'short_description' => $this->plugin["Description"],
+					'sections'		=> array(
+						'Description'	  => $this->plugin["Description"],
+						'Updates'		    => $this->github_response['body'],
+					),
+					'download_link'	=> $this->github_response['zipball_url']
+				);
+
+				return (object) $plugin; // Return the data
+			}
+
+		}
+		return $result; // Otherwise return default
+	}
+
+	public function after_install( $response, $hook_extra, $result ) {
+		global $wp_filesystem; // Get global FS object
+
+		$install_directory = plugin_dir_path( $this->file ); // Our plugin directory
+		$wp_filesystem->move( $result['destination'], $install_directory ); // Move files to the plugin dir
+		$result['destination'] = $install_directory; // Set the destination for the rest of the stack
+
+		if ( $this->active ) { // If it was active
+			activate_plugin( $this->basename ); // Reactivate
+		}
+
+		return $result;
+	}
+}
+
+?>


### PR DESCRIPTION
Moving plugin hosting to GitHub.  This requires implementing our own updater. 


Mad props to [Smashing Magazine](https://www.smashingmagazine.com/2015/08/deploy-wordpress-plugins-with-github-using-transients/) for their great tutorial!